### PR TITLE
Change of scoring + list --active-servers + Better tables

### DIFF
--- a/nordnm/benchmarking.py
+++ b/nordnm/benchmarking.py
@@ -10,6 +10,8 @@ import subprocess
 from decimal import Decimal
 import resource
 
+EXP_SENSITIVITY = 50  # Controls the gradient of the exponential score function. The higher the number, the smaller the gradient (change)
+
 
 def get_server_score(server, ping_attempts):
     load = server['load']
@@ -23,7 +25,7 @@ def get_server_score(server, ping_attempts):
         rtt, loss = utils.get_rtt_loss(ip_addr, ping_attempts)
 
         if loss < 5:  # Similarly, if packet loss is >= 5%, the connection is not reliable. Keep the starting score.
-            score = round(Decimal(1 / (numpy.exp((load/100) * rtt))), 6)  # Maximise the score for smaller values of ln(load + rtt)
+            score = round(Decimal(1 / (numpy.exp(((load/100) * rtt) / EXP_SENSITIVITY))), 4)  # Maximise the score for smaller values of ln(load + rtt)
 
     return (score, load, rtt)
 

--- a/nordnm/benchmarking.py
+++ b/nordnm/benchmarking.py
@@ -16,15 +16,16 @@ def get_server_score(server, ping_attempts):
     ip_addr = server['ip_address']
 
     score = 0  # Lowest starting score
+    rtt = None
 
-    # If a server is at 100% load, we don't need to waste time pinging. Just keep starting score.
-    if load < 100:
+    # If a server is at 90% load or greater, we don't need to waste time pinging. Just keep starting score.
+    if load < 90:
         rtt, loss = utils.get_rtt_loss(ip_addr, ping_attempts)
 
         if loss < 5:  # Similarly, if packet loss is >= 5%, the connection is not reliable. Keep the starting score.
-            score = round(Decimal(1 / numpy.log(load + rtt)), 4)  # Maximise the score for smaller values of ln(load + rtt)
+            score = round(Decimal(1 / (numpy.exp((load/100) * rtt))), 6)  # Maximise the score for smaller values of ln(load + rtt)
 
-    return score
+    return (score, load, rtt)
 
 
 def compare_server(server, best_servers, ping_attempts, valid_protocols):
@@ -36,7 +37,7 @@ def compare_server(server, best_servers, ping_attempts, valid_protocols):
 
     country_code = server['flag']
     domain = server['domain']
-    score = get_server_score(server, ping_attempts)
+    score, load, latency = get_server_score(server, ping_attempts)
 
     for category in server['categories']:
         category_name = nordapi.VPN_CATEGORIES[category['name']]
@@ -49,7 +50,7 @@ def compare_server(server, best_servers, ping_attempts, valid_protocols):
 
             if score > best_score:
                 name = nordnm.generate_connection_name(server, protocol)
-                best_servers[country_code, category_name, protocol] = {'name': name, 'domain': domain, 'score': score}
+                best_servers[country_code, category_name, protocol] = {'name': name, 'domain': domain, 'score': score, 'load': load, 'latency': latency}
 
 
 def get_num_processes(num_servers):

--- a/nordnm/networkmanager.py
+++ b/nordnm/networkmanager.py
@@ -237,7 +237,6 @@ def set_auto_connect(connection_name):
                 print(auto_script, file=auto_connect)
 
             utils.make_executable(paths.AUTO_CONNECT_SCRIPT)
-            logger.info("Auto-connect enabled for '%s'.", connection_name)
             return True
         except Exception as e:
             logger.error("Error attempting to set auto-conect: %s" % e)

--- a/nordnm/nordnm.py
+++ b/nordnm/nordnm.py
@@ -199,8 +199,13 @@ class NordNM(object):
               "    \_| \_/\___/|_|  \__,_\_| \_/\_|  |_/   v%s\n" % version_string)
 
     def print_categories(self):
+        format_string = "| %-10s | %-20s |"
+        print("\n Note: You must use the short name in this tool.\n")
+        print(format_string % ("SHORT NAME", "LONG NAME"))
+        print("|------------+----------------------|")
+
         for long_name, short_name in nordapi.VPN_CATEGORIES.items():
-            print("%-9s (%s)" % (short_name, long_name))
+            print(format_string % (short_name, long_name))
 
         print()  # For spacing
 

--- a/nordnm/nordnm.py
+++ b/nordnm/nordnm.py
@@ -16,7 +16,7 @@ from fnmatch import fnmatch
 import logging
 import copy
 from timeit import default_timer as timer
-from typing import Union
+from distutils.version import StrictVersion
 
 
 def generate_connection_name(server, protocol):
@@ -186,9 +186,9 @@ class NordNM(object):
         version_string = __version__
 
         latest_version = utils.get_pypi_package_version(__package__)
-        if latest_version and version_string != latest_version:  # There's a new version on PyPi
+        if latest_version and StrictVersion(version_string) < StrictVersion(latest_version):  # There's a new version on PyPi
             version_string = version_string + " (v" + latest_version + " available!)"
-        elif latest_version and version_string == latest_version:
+        else:
             version_string = version_string + " (Latest)"
 
         print("     _   _               _ _   _ ___  ___\n"
@@ -337,7 +337,7 @@ class NordNM(object):
 
         return ovpn_path
 
-    def enable_auto_connect(self, country_code: str, category: str='normal', protocol: Union['tcp', 'udp']='tcp'):
+    def enable_auto_connect(self, country_code: str, category: str='normal', protocol: str='tcp'):
         enabled = False
         selected_parameters = (country_code.upper(), category, protocol)
 

--- a/nordnm/nordnm.py
+++ b/nordnm/nordnm.py
@@ -202,6 +202,8 @@ class NordNM(object):
         for long_name, short_name in nordapi.VPN_CATEGORIES.items():
             print("%-9s (%s)" % (short_name, long_name))
 
+        print()  # For spacing
+
     def print_countries(self):
         servers = nordapi.get_server_list(sort_by_country=True)
         if servers:
@@ -218,6 +220,8 @@ class NordNM(object):
                     countries.append(country_code)
                     country_name = server['country']
                     print(format_string % (country_name, country_code))
+
+            print()  # For spacing
         else:
             self.logger.error("Could not get available countries from the NordVPN API.")
 
@@ -241,6 +245,7 @@ class NordNM(object):
                     latency = round(self.active_servers[params]['latency'], 2)
                     print(format_string % (name, load, latency, score))
 
+            print()  # For spacing
         else:
             self.logger.warning("No active servers to display.")
 


### PR DESCRIPTION
- The scoring function has been changed to not accept servers with greater than 90% load. The function itself now uses an inverse exponential score, which gives a better spread. (Although a lot of values come out as 0.0000.. so it needs some tweaking)
- You can now list active servers with their metrics using nordnm l --active-servers
- Fixed table layout of list options
- On auto-connect server metrics are now shown