### PR TITLE
Correct Onion over VPN -> Onion Over VPN

### DIFF
--- a/nordnm/nordapi.py
+++ b/nordnm/nordapi.py
@@ -13,7 +13,7 @@ VPN_CATEGORIES = {
     'P2P': 'p2p',
     'Double VPN': 'double',
     'Dedicated IP servers': 'dedicated',
-    'Onion over VPN': 'onion',
+    'Onion Over VPN': 'onion',
     'Anti DDoS': 'ddos',
 }
 


### PR DESCRIPTION
Because of a letter (o) the tool was not synchronizing the Onion network servers.