### PR TITLE
Overwriting /etc/resolv.conf only with DNS servers denoted by NordVPN.

### DIFF
--- a/nordnm/networkmanager.py
+++ b/nordnm/networkmanager.py
@@ -46,11 +46,8 @@ class ConnectionConfig(object):
     def disable_ipv6(self):
         self.config['ipv6']['method'] = 'ignore'
 
-    def set_dns_nameservers(self, dns_list):
-        dns_string = ';'.join(map(str, dns_list))
-
-        self.config['ipv4']['dns'] = dns_string
-        self.config['ipv4']['ignore-auto-dns'] = 'true'
+    def set_dns_nameservers(self):
+        self.config['ipv4']['dns-priority'] = '-1'
 
     def set_user(self, user):
         self.config['connection']['permissions'] = "user:" + user + ":;"
@@ -368,12 +365,10 @@ def import_connection(file_path, connection_name, username=None, password=None, 
             if username and password:
                 config.set_credentials(username, password)
 
-            if dns_list:
-                config.set_dns_nameservers(dns_list)
-
             if not ipv6:
                 config.disable_ipv6()
 
+            config.set_dns_nameservers()
             user = utils.get_current_user()
             config.set_user(user)
 

--- a/nordnm/networkmanager.py
+++ b/nordnm/networkmanager.py
@@ -46,8 +46,14 @@ class ConnectionConfig(object):
     def disable_ipv6(self):
         self.config['ipv6']['method'] = 'ignore'
 
-    def set_dns_nameservers(self):
+    def set_dns_nameservers(self, dns_list):
         self.config['ipv4']['dns-priority'] = '-1'
+
+        if dns_list:
+            dns_string = ';'.join(map(str, dns_list))
+
+            self.config['ipv4']['dns'] = dns_string
+            self.config['ipv4']['ignore-auto-dns'] = 'true'
 
     def set_user(self, user):
         self.config['connection']['permissions'] = "user:" + user + ":;"
@@ -309,7 +315,7 @@ def import_connection(file_path, connection_name, username=None, password=None, 
             if not ipv6:
                 config.disable_ipv6()
 
-            config.set_dns_nameservers()
+            config.set_dns_nameservers(dns_list)
             user = utils.get_current_user()
             config.set_user(user)
 

--- a/nordnm/nordnm.py
+++ b/nordnm/nordnm.py
@@ -535,8 +535,6 @@ class NordNM(object):
 
         # Check if there are custom DNS servers specified in the settings before loading the defaults
         dns_list = self.settings.get_custom_dns_servers()
-        if not dns_list:
-            dns_list = nordapi.get_nameservers()
 
         if not self.configs_exist():
             self.logger.warning("No OpenVPN configuration files found.")
@@ -613,7 +611,7 @@ class NordNM(object):
 
                         file_path = self.get_ovpn_path(domain, protocol)
                         if file_path:
-                            if networkmanager.import_connection(file_path, name, username, password):
+                            if networkmanager.import_connection(file_path, name, username, password, dns_list):
                                 updated = True
                                 new_connections += 1
                             else:

--- a/nordnm/settings.py
+++ b/nordnm/settings.py
@@ -134,6 +134,7 @@ class SettingsHandler(object):
     def get_custom_dns_servers(self) -> list:
         try:
             custom_dns = self.settings.get('DNS', 'custom-dns-servers')
-            return custom_dns.split(' ')
+            if custom_dns:
+                return custom_dns.split(' ')
         except (configparser.NoSectionError, configparser.NoOptionError):  # The setting didn't exist, so ignore it
             return []


### PR DESCRIPTION
My contribution related to this comment: https://github.com/Chadsr/NordVPN-NetworkManager/issues/90#issuecomment-386776779.

So the script is only needed for use of custom DNS.

The `get_nameservers` function in `nordapi.py` can be completely removed.
