### PR TITLE
Fixed bug: connecting to VPN until timeout

### DIFF
--- a/nordnm/networkmanager.py
+++ b/nordnm/networkmanager.py
@@ -215,7 +215,7 @@ def set_auto_connect(connection_name):
         auto_script = (
             '#!/bin/bash\n\n'
             'if [[ "$1" =~ ' + interface_string + ' ]] && [[ "$2" =~ up|connectivity-change ]]; then\n'
-            '  nmcli con up id "' + connection_name + '"\n'
+            '  nmcli con up id "' + connection_name + '" &\n'
             'fi\n'
             )
 


### PR DESCRIPTION
This bug occurs when there is a pre-up hook in `/etc/NetworkManager/dispatcher.d/pre-up.d/`.
Way to reproduce:
1. Create a dummy script that handles pre-up events.
```sh
echo '#!/bin/sh' | sudo tee /etc/NetworkManager/dispatcher.d/pre-up.d/foo
sudo chmod 0700 /etc/NetworkManager/dispatcher.d/pre-up.d/foo
```
2. Try disconnecting and connecting again to wifi network with nordnm auto-connect enabled.
3. You should see the NetworkManager trying to establish VPN connection for about 90 seconds until it succeeds.

This creates dummy script foo that is a hook for `pre-up` events. This causes nm-dispatcher to run other scripts (including nordnm auto-connect script) to be additionally run on `pre-up` events. The problem is that nordnm auto-connect script runs `nmcli con up id ...` which causes dispatcher `pre-up` events to be created. Then hooks are run for this new events but as nordnm auto-connect script is still running, the nm-dispatcher is waiting for already running instance to finish before running it again (that is only my suspicion, but this looks like so) - maybe to prevent infinite recursion... Anyway, we have a situation as follows:
nordnm auto-connect script waits for `nmcli con up id ...` to end, which waits to run nordnm auto-connect script again (for pre-up event), which is not happening until the first nordnm auto-connect script is still running (we have a deadlock).
To see a detailed log of what is happening you may find `sudo journalctl -u NetworkManager-dispatcher.service -f` command helpful.
It is a pity that this deadlocks, as nordnm auto-connect script have nothing to do on `pre-up` events, but it is happening.
So my solution is to run `nmcli con up id ...` in the background so that deadlock won't occur. It seems to solve the problem.