### PR TITLE
Privilege handling fixes

### DIFF
--- a/nordnm/networkmanager.py
+++ b/nordnm/networkmanager.py
@@ -30,7 +30,7 @@ def restart():
 
         return False
 
-    # Requires root priveledge
+    # Requires root privilege
     return utils.run_as_root(main)
 
 
@@ -54,20 +54,24 @@ def get_version():
 
 
 def reload_connections():
-    try:
-        output = subprocess.run(['nmcli', 'connection', 'reload'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        output.check_returncode()
+    def main():
+        try:
+            output = subprocess.run(['nmcli', 'connection', 'reload'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            output.check_returncode()
 
-        return True
+            return True
 
-    except subprocess.CalledProcessError:
-        error = utils.format_std_string(output.stderr)
-        logger.error(error)
-        return False
+        except subprocess.CalledProcessError:
+            error = utils.format_std_string(output.stderr)
+            logger.error(error)
+            return False
 
-    except Exception as ex:
-        logger.error(ex)
-        return False
+        except Exception as ex:
+            logger.error(ex)
+            return False
+
+    # Requires root privilege
+    return utils.run_as_root(main)
 
 
 def get_vpn_connections():
@@ -149,7 +153,7 @@ def set_global_mac_address(value):
             logger.error("Could not get the version of NetworkManager in use. Aborting.")
             return False
 
-    # Requires root priveledge
+    # Requires root privilege
     return utils.run_as_root(main)
 
 
@@ -166,7 +170,7 @@ def remove_global_mac_address():
 
         return False
 
-    # Requires root priveledge
+    # Requires root privilege
     return utils.run_as_root(main)
 
 def remove_killswitch(log=True):
@@ -190,7 +194,7 @@ def remove_killswitch(log=True):
 
         return False
 
-    # Requires root priveledge
+    # Requires root privilege
     return utils.run_as_root(main)
 
 
@@ -223,7 +227,7 @@ def set_killswitch(log=True):
             logger.error("Error attempting to set kill-switch: %s" % e)
             return False
 
-    # Requires root priveledge
+    # Requires root privilege
     return utils.run_as_root(main)
 
 
@@ -254,7 +258,7 @@ def set_auto_connect(connection_name):
 
         return False
 
-    # Requires root priveledge
+    # Requires root privilege
     return utils.run_as_root(main)
 
 
@@ -271,7 +275,7 @@ def remove_autoconnect():
 
         return False
 
-    # Requires root priveledge
+    # Requires root privilege
     return utils.run_as_root(main)
 
 
@@ -289,6 +293,7 @@ def import_connection(file_path, connection_name, username=None, password=None, 
             output = subprocess.run(['nmcli', 'connection', 'import', 'type', 'openvpn', 'file', temp_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             os.remove(temp_path) # Remove the temporary renamed config we created
             output.check_returncode()
+            return True
         except subprocess.CalledProcessError:
             error = utils.format_std_string(output.stderr)
             logger.error("Could not add options to the connection: %s" % error)
@@ -315,22 +320,26 @@ def import_connection(file_path, connection_name, username=None, password=None, 
         connection_options['+ipv4.dns'] = [dns_string]
         connection_options['+ipv4.ignore-auto-dns'] = ['true']
 
-    try:
-        for location, values in connection_options.items():
-            for value in values:
-                output = subprocess.run(['nmcli', 'connection', 'modify', connection_name, location, value], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                output.check_returncode()
+    def nmcli_modify():
+        try:
+            for location, values in connection_options.items():
+                for value in values:
+                    output = subprocess.run(['nmcli', 'connection', 'modify', connection_name, location, value], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    output.check_returncode()
 
-        return True
+            return True
 
-    except subprocess.CalledProcessError:
-        error = utils.format_std_string(output.stderr)
-        logger.error("Could not add options to the connection: %s" % error)
-        return False
+        except subprocess.CalledProcessError:
+            error = utils.format_std_string(output.stderr)
+            logger.error("Could not add options to the connection: %s" % error)
+            return False
 
-    except Exception as ex:
-        logger.error(ex)
-        return False
+        except Exception as ex:
+            logger.error(ex)
+            return False
+
+    # Requires root privilege
+    return utils.run_as_root(nmcli_modify)
 
 
 def enable_connection(connection_name):

--- a/nordnm/nordnm.py
+++ b/nordnm/nordnm.py
@@ -353,15 +353,19 @@ class NordNM(object):
             return None
 
     def delete_configs(self):
-        for f in os.listdir(paths.OVPN_CONFIGS):
-            file_path = os.path.join(paths.OVPN_CONFIGS, f)
-            try:
-                if os.path.isfile(file_path):
-                    os.unlink(file_path)
-                elif os.path.isdir(file_path):
-                    shutil.rmtree(file_path)
-            except Exception as e:
-                self.logger.error("Could not delete config file: %s" % e)
+        def main():
+            for f in os.listdir(paths.OVPN_CONFIGS):
+                file_path = os.path.join(paths.OVPN_CONFIGS, f)
+                try:
+                    if os.path.isfile(file_path):
+                        os.unlink(file_path)
+                    elif os.path.isdir(file_path):
+                        shutil.rmtree(file_path)
+                except Exception as e:
+                    self.logger.error("Could not delete config file: %s" % e)
+
+        # Requires root privilege
+        return utils.run_as_root(main)
 
     def get_configs(self):
         self.logger.info("Downloading latest NordVPN OpenVPN configuration files to '%s'." % paths.OVPN_CONFIGS)
@@ -446,6 +450,7 @@ class NordNM(object):
         self.logger.info("Data directory '%s' removed successfully!" % paths.ROOT)
         return True
 
+
     def create_directories(self):
         if not os.path.exists(paths.ROOT):
             os.mkdir(paths.ROOT)
@@ -458,7 +463,7 @@ class NordNM(object):
 
         try:
             files = glob.glob(paths.OVPN_CONFIGS + '/**/' + domain + '.' + protocol + '*.ovpn')
-            
+
             if not files:
                 return False
 


### PR DESCRIPTION
Should fix #121.

Was missing a "good" return in `reload_connections()`, also some more functions
seemingly have to be run as root (although it might be possible some only
need to remain root-run because of previously running everything as root
and thus having some problematic folder permissions).