### PR TITLE
fix LANG=C breaking subprocess.run

### DIFF
--- a/nordnm/utils.py
+++ b/nordnm/utils.py
@@ -114,12 +114,15 @@ def make_executable(file_path):
 
 def get_rtt_loss(host, ping_attempts):
     try:
+        ping_env = os.environ.copy()
+        ping_env["LANG"] = "C"
         output = subprocess.run([
-            '(', 'export LANG=C;', 'ping', '-c',
-            str(ping_attempts), '-n', '-i', '0.2', '-W', '1', host, ')'
+            'ping', '-c', str(ping_attempts),
+            '-n', '-i', '0.2', '-W', '1', host
         ],
                                 stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+                                stderr=subprocess.PIPE,
+                                env=ping_env)
         output.check_returncode()
 
         lines = output.stdout.decode('utf-8').splitlines()


### PR DESCRIPTION
Syncing connections failed for me due to the change introduced in b68c654244870cdb069e3b2c02ae99e455feae53.

This PR attempts to fix this by setting the environment variable `LANG` via `env=` with `subprocess.run()`.